### PR TITLE
allow client to be fully configurable via ENV variables

### DIFF
--- a/lib/immudb/client.rb
+++ b/lib/immudb/client.rb
@@ -28,11 +28,11 @@ module Immudb
         database ||= uri.path.sub(/\A\//, "")
       end
 
-      host ||= "localhost"
-      port ||= 3322
-      username ||= "immudb"
-      password ||= "immudb"
-      database ||= "defaultdb"
+      host ||= ENV.fetch("IMMUDBHOST","localhost")
+      port ||= ENV.fetch("IMMUDBPORT","3322")
+      username ||= ENV.fetch("IMMUDBUSER","immudb")
+      password ||= ENV.fetch("IMMUDBPASS","immudb")
+      database ||= ENV.fetch("IMMUDBDATABASE","defaultdb")
 
       raise ArgumentError, "Invalid host" if host.include?(":")
 


### PR DESCRIPTION
This change mirror how PG support PGUSER, PGPASSWORD .

reference: https://www.postgresql.org/docs/current/libpq-envars.html